### PR TITLE
Change raise StopIteration to return

### DIFF
--- a/pyevmasm/evmasm.py
+++ b/pyevmasm/evmasm.py
@@ -681,7 +681,7 @@ def disassemble_all(bytecode, pc=0):
     while True:
         instr = disassemble_one(bytecode, pc=pc)
         if not instr:
-            raise StopIteration
+            return
         pc += instr.size
         yield instr
 


### PR DESCRIPTION
Before this change:
```
(pyevmasm) dc@ubuntu:~/projects/pyevmasm/tests$ PYTHONPATH=../pyevmasm python test_EVMAssembler.py
test_EVMAssembler.py:21: DeprecationWarning: generator 'disassemble_all' raised StopIteration
  self.assertTrue(all(a == b for a, b in zip(instructions1, instructions2)))
/home/dc/projects/pyevmasm/pyevmasm/evmasm.py:1007: DeprecationWarning: generator 'disassemble_all' raised StopIteration
  return '\n'.join(map(str, disassemble_all(bytecode, pc=pc, fork=fork)))
......
----------------------------------------------------------------------
Ran 6 tests in 0.003s

OK
```

After this change:
```
(pyevmasm) dc@ubuntu:~/projects/pyevmasm/tests$ PYTHONPATH=../pyevmasm python test_EVMAssembler.py ......
----------------------------------------------------------------------
Ran 6 tests in 0.002s

OK
```